### PR TITLE
Webpack production build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Webpack Babel Starter Kit",
   "main": "''",
   "scripts": {
-    "build": "webpack --progress --profile --colors",
+    "build": "NODE_ENV=production webpack -p --config webpack.production.config.js --progress --profile --colors",
     "dev": "webpack-dev-server --progress --profile --colors --hot"
   },
   "repository": {

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -1,0 +1,40 @@
+module.exports = [
+	{
+		test: /\.jsx?$/,
+		exclude: /(node_modules|bower_components)/,
+		loaders: ['react-hot', 'babel'],
+	},
+
+	{
+		test: /\.css$/,
+		loader: 'style-loader!css-loader'
+	},
+	{
+		test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+		loader: "file"
+	},
+	{
+		test: /\.(woff|woff2)$/,
+		loader: "url?prefix=font/&limit=5000"
+	},
+	{
+		test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+		loader: "url?limit=10000&mimetype=application/octet-stream"
+	},
+	{
+		test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+		loader: "url?limit=10000&mimetype=image/svg+xml"
+	},
+	{
+		test: /\.gif/,
+		loader: "url-loader?limit=10000&mimetype=image/gif"
+	},
+	{
+		test: /\.jpg/,
+		loader: "url-loader?limit=10000&mimetype=image/jpg"
+	},
+	{
+		test: /\.png/,
+		loader: "url-loader?limit=10000&mimetype=image/png"
+	}
+];

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -4,11 +4,8 @@ var loaders = require('./webpack.loaders');
 
 module.exports = {
 	entry: [
-		'webpack-dev-server/client?http://0.0.0.0:8080', // WebpackDevServer host and port
-		'webpack/hot/only-dev-server',
 		'./index.jsx' // Your appʼs entry point
 	],
-	devtool: process.env.WEBPACK_DEVTOOL || 'source-map',
 	output: {
 		path: path.join(__dirname, 'public'),
 		filename: 'bundle.js'
@@ -18,14 +15,5 @@ module.exports = {
 	},
 	module: {
 		loaders: loaders
-	},
-	devServer: {
-		contentBase: "./public",
-			noInfo: true, //  --no-info option
-			hot: true,
-			inline: true
-		},
-	plugins: [
-		new webpack.NoErrorsPlugin()
-	]
+	}
 };


### PR DESCRIPTION
This PR adds a basic production config, so that `npm run build` works as expected out-of-the-box.

Changes:
* Added a simple `webpack.production.config.js`.
* Moved loaders from `webpack.config.js` into `webpack.loaders.js` so that they can be shared by production and dev configs (easier to maintain).
* Updated `npm run build` command to pass `production` flag to webpack.

A bonus is that the size of `bundle.js` is now **313kb** instead of **1.05mb**. 🎊 