### PR TITLE
(fix) production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Webpack Babel Starter Kit",
   "main": "''",
   "scripts": {
-    "build": "NODE_ENV=production webpack -p --config webpack.production.config.js --progress --profile --colors",
+    "build": "webpack -p --config webpack.production.config.js --progress --profile --colors",
     "dev": "webpack-dev-server --progress --profile --colors --hot"
   },
   "repository": {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -15,5 +15,12 @@ module.exports = {
 	},
 	module: {
 		loaders: loaders
-	}
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			'process.env': {
+				NODE_ENV: '"production"'
+			}
+		})
+	]
 };


### PR DESCRIPTION
React warns that the development build of React is being used after the
production build script is executed.

To fix this a Webpack plugin is created that sets the NODE_ENV to
‘production’.