### PR TITLE
fix HotModuleReplacementPlugin conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "''",
   "scripts": {
     "build": "webpack -p --config webpack.production.config.js --progress --profile --colors",
-    "dev": "webpack-dev-server --progress --profile --colors --hot"
+    "dev": "webpack-dev-server --progress --profile --colors"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removes the --hot option from npm scripts, because it's conflicting and throwing an error when hot reload components.

Reference:
https://github.com/gaearon/react-hot-loader/issues/77