### PR TITLE
Add class transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "6.13.2",
-    "babel-preset-es2017": "^6.14.0",
     "babel-preset-react": "6.11.1",
     "babel-runtime": "^6.11.6",
     "css-loader": "0.23.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,13 @@
   "devDependencies": {
     "babel-core": "6.13.2",
     "babel-loader": "6.2.4",
+    "babel-plugin-transform-class-properties": "^6.11.5",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "6.13.2",
+    "babel-preset-es2017": "^6.14.0",
     "babel-preset-react": "6.11.1",
+    "babel-runtime": "^6.11.6",
     "css-loader": "0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "0.9.0",

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -1,8 +1,30 @@
 module.exports = [
+	// {
+	// 	test: /\.jsx?$/,
+	// 	exclude: /(node_modules|bower_components)/,
+ //    loaders: [
+ //      {
+ //        loader: 'babel',
+ //        query: {
+ //          presets: ['es2015', 'es2017', 'react'],
+ //          plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
+ //        },
+ //      },
+ //    ],
+ //  },
 	{
 		test: /\.jsx?$/,
 		exclude: /(node_modules|bower_components)/,
-		loaders: ['react-hot', 'babel'],
+		loaders: ['react-hot']
+	},
+	{
+		test: /\.jsx?$/,
+		exclude: /(node_modules|bower_components)/,
+		loader: 'babel',
+		query: {
+		  presets: ['es2015', 'es2017', 'react'],
+		  plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
+		}
 	},
 	{
 		test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -1,17 +1,4 @@
 module.exports = [
-	// {
-	// 	test: /\.jsx?$/,
-	// 	exclude: /(node_modules|bower_components)/,
- //    loaders: [
- //      {
- //        loader: 'babel',
- //        query: {
- //          presets: ['es2015', 'es2017', 'react'],
- //          plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
- //        },
- //      },
- //    ],
- //  },
 	{
 		test: /\.jsx?$/,
 		exclude: /(node_modules|bower_components)/,
@@ -22,7 +9,7 @@ module.exports = [
 		exclude: /(node_modules|bower_components)/,
 		loader: 'babel',
 		query: {
-		  presets: ['es2015', 'es2017', 'react'],
+		  presets: ['es2015', 'react'],
 		  plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
 		}
 	},


### PR DESCRIPTION
❤️  the project! Nice and tidy.

The existing project doesn't support the use of [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions), which are particularly useful in react development. I don't fully understand why as I thought they were part of ES6 syntax, but at any rate, adding support for the Babel class transform seems to sort this.