### PR TITLE
Fixed double encoding of PNG's and fonts

### DIFF
--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -47,8 +47,5 @@ module.exports = [
 		test: /\.png/,
 		exclude: /(node_modules|bower_components)/,
 		loader: "url-loader?limit=10000&mimetype=image/png"
-	},
-	{ test: /\.(png|woff|woff2|eot|ttf|svg)$/,
-		loader: 'url-loader?limit=100000'
 	}
 ];


### PR DESCRIPTION
I'm definitely a newbie, but this bit caused double encoding/loading of all my png's and font files.