### PR TITLE
Add postcss with autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "0.9.0",
     "html-webpack-plugin": "^2.22.0",
+    "postcss-loader": "^1.0.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,16 @@
+const AUTOPREFIXER_BROWSERS = [
+  'Android 2.3',
+  'Android >= 4',
+  'Chrome >= 35',
+  'Firefox >= 31',
+  'Explorer >= 9',
+  'iOS >= 7',
+  'Opera >= 12',
+  'Safari >= 7.1',
+];
+
+module.exports = {
+	plugins: [
+		require('autoprefixer')({ browsers: AUTOPREFIXER_BROWSERS })
+	]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ loaders.push({
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
+		'postcss',
 		'sass'
 	]
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ loaders.push({
 // local scss modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
+	exclude: /(node_modules|bower_components|public)/,
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
@@ -28,6 +29,7 @@ loaders.push({
 // local css modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.css/,
+	exclude: /(node_modules|bower_components|public)/,
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,16 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const HOST = process.env.HOST || "127.0.0.1";
 const PORT = process.env.PORT || "8888";
-
+const AUTOPREFIXER_BROWSERS = [
+  'Android 2.3',
+  'Android >= 4',
+  'Chrome >= 35',
+  'Firefox >= 31',
+  'Explorer >= 9',
+  'iOS >= 7',
+  'Opera >= 12',
+  'Safari >= 7.1',
+];
 // global css
 loaders.push({
 	test: /[\/\\](node_modules|global)[\/\\].*\.css$/,
@@ -18,10 +27,10 @@ loaders.push({
 // local scss modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
-	exclude: /(node_modules|bower_components|public)/,
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
+		'postcss',
 		'sass'
 	]
 });
@@ -29,7 +38,6 @@ loaders.push({
 // local css modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.css/,
-	exclude: /(node_modules|bower_components|public)/,
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]'
@@ -72,5 +80,8 @@ module.exports = {
 		new HtmlWebpackPlugin({
 			template: './src/template.html'
 		}),
-	]
+	],
+	postcss: [
+    	require('autoprefixer')({ browsers: AUTOPREFIXER_BROWSERS })
+  	]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,16 +6,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const HOST = process.env.HOST || "127.0.0.1";
 const PORT = process.env.PORT || "8888";
-const AUTOPREFIXER_BROWSERS = [
-  'Android 2.3',
-  'Android >= 4',
-  'Chrome >= 35',
-  'Firefox >= 31',
-  'Explorer >= 9',
-  'iOS >= 7',
-  'Opera >= 12',
-  'Safari >= 7.1',
-];
+
 // global css
 loaders.push({
 	test: /[\/\\](node_modules|global)[\/\\].*\.css$/,
@@ -80,8 +71,5 @@ module.exports = {
 		new HtmlWebpackPlugin({
 			template: './src/template.html'
 		}),
-	],
-	postcss: [
-    	require('autoprefixer')({ browsers: AUTOPREFIXER_BROWSERS })
-  	]
+	]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,6 @@ loaders.push({
 	loaders: [
 		'style?sourceMap',
 		'css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
-		'postcss',
 		'sass'
 	]
 });

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -17,7 +17,7 @@ loaders.push({
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
 	exclude: /(node_modules|bower_components|public)/,
-	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss!sass')
+	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'sass')
 });
 // global css files
 loaders.push({

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		}),
 		new HtmlWebpackPlugin({
 			template: './src/template.html',
-			title: 'To-Do List'
+			title: 'Webpack App'
 		}),
 		new webpack.optimize.DedupePlugin()
 	]

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -6,18 +6,27 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var WebpackCleanupPlugin = require('webpack-cleanup-plugin');
 
+const AUTOPREFIXER_BROWSERS = [
+  'Android 2.3',
+  'Android >= 4',
+  'Chrome >= 35',
+  'Firefox >= 31',
+  'Explorer >= 9',
+  'iOS >= 7',
+  'Opera >= 12',
+  'Safari >= 7.1',
+];
+
 // local css modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.css/,
-	exclude: /(node_modules|bower_components|public)/,
 	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')
 });
 
 // local scss modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
-	exclude: /(node_modules|bower_components|public)/,
-	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'sass')
+	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss!sass')
 });
 // global css files
 loaders.push({
@@ -60,8 +69,11 @@ module.exports = {
 		}),
 		new HtmlWebpackPlugin({
 			template: './src/template.html',
-			title: 'Webpack App'
+			title: 'To-Do List'
 		}),
 		new webpack.optimize.DedupePlugin()
-	]
+	],
+	postcss: [
+    	require('autoprefixer')({ browsers: AUTOPREFIXER_BROWSERS })
+  	]
 };

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -6,17 +6,6 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var WebpackCleanupPlugin = require('webpack-cleanup-plugin');
 
-const AUTOPREFIXER_BROWSERS = [
-  'Android 2.3',
-  'Android >= 4',
-  'Chrome >= 35',
-  'Firefox >= 31',
-  'Explorer >= 9',
-  'iOS >= 7',
-  'Opera >= 12',
-  'Safari >= 7.1',
-];
-
 // local css modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.css/,
@@ -72,8 +61,5 @@ module.exports = {
 			title: 'To-Do List'
 		}),
 		new webpack.optimize.DedupePlugin()
-	],
-	postcss: [
-    	require('autoprefixer')({ browsers: AUTOPREFIXER_BROWSERS })
-  	]
+	]
 };

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -17,7 +17,7 @@ loaders.push({
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
 	exclude: /(node_modules|bower_components|public)/,
-	loader: ExtractTextPlugin.extract('style', 'css!sass?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')
+	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss!sass')
 });
 // global css files
 loaders.push({

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -9,12 +9,14 @@ var WebpackCleanupPlugin = require('webpack-cleanup-plugin');
 // local css modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.css/,
+	exclude: /(node_modules|bower_components|public)/,
 	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')
 });
 
 // local scss modules
 loaders.push({
 	test: /[\/\\]src[\/\\].*\.scss/,
+	exclude: /(node_modules|bower_components|public)/,
 	loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss!sass')
 });
 // global css files


### PR DESCRIPTION
Added the postcss-loader so that the autoprefixer can be used. Also fixed a bug in the webpack.production.config.js, where the sequence of loaders provided together with their parameters was not correct. The sass loader has to placed after the css?modules loader. 