### PR TITLE
Workaround for chrome bug

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,7 +5,7 @@ import App from './app.jsx';
 
 render( <AppContainer><App/></AppContainer>, document.querySelector("#app"));
 
-if (module.hot) {
+if (module && module.hot) {
   module.hot.accept('./app.jsx', () => {
     const App = require('./app.jsx').default;
     render(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
 		'react-hot-loader/patch',
 		'./src/index.jsx' // your app's entry point
 	],
-	devtool: process.env.WEBPACK_DEVTOOL || 'cheap-module-source-map',
+	devtool: process.env.WEBPACK_DEVTOOL || 'eval-source-map',
 	output: {
 		path: path.join(__dirname, 'public'),
 		filename: 'bundle.js'


### PR DESCRIPTION
Chrome dev tool breakpoints don't work really well with `cheap-module-source-map`
See: https://github.com/webpack/webpack/issues/2145