### PR TITLE
added publicPath to output.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
 	],
 	devtool: process.env.WEBPACK_DEVTOOL || 'eval-source-map',
 	output: {
+		publicPath: '/',
 		path: path.join(__dirname, 'public'),
 		filename: 'bundle.js'
 	},

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -30,6 +30,7 @@ module.exports = {
 		'./src/index.jsx'
 	],
 	output: {
+		publicPath: '/',
 		path: path.join(__dirname, 'public'),
 		filename: '[chunkhash].js'
 	},


### PR DESCRIPTION
Added publicPath: '/' to the ouput in webapack and webpack.production.","body":"Relative path after build was causing an issue. The static server I was using was unable to find the js and css bundle when refreshing the page on a route.\nHaving publicPath set to '/' solved it.