### PR TITLE
Add webpack-dashboard plugin and dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Try this is a simple [React](https://facebook.github.io/react/), [Webpack](http:
 * Webpack configuration for development (with hot reloading) and production (with minification).
 * CSS module loading, so you can include your css by ```import styles from './path/to.css';```.
 * Both js(x) and css hot loaded during development.
+* [Webpack Dashboard Plugin](https://github.com/FormidableLabs/webpack-dashboard) on dev server.
 
 ### To run
 
@@ -31,6 +32,12 @@ npm install
 
 ```
 npm start
+```
+
+* Or you can run development server with [webpack-dashboard](https://github.com/FormidableLabs/webpack-dashboard):
+
+```
+npm run dev
 ```
 
 Open the web browser to `http://localhost:8888/`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "webpack --config webpack.production.config.js --progress --profile --colors",
     "start": "webpack-dev-server --progress --profile --colors",
-    "lint": "eslint --ext js --ext jsx src || exit 0"
+    "lint": "eslint --ext js --ext jsx src || exit 0",
+    "dev": " webpack-dashboard -- webpack-dev-server --progress --profile --colors"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,7 @@
     "url-loader": "0.5.7",
     "webpack": "1.14.0",
     "webpack-cleanup-plugin": "^0.4.1",
+    "webpack-dashboard": "^0.2.0",
     "webpack-dev-server": "1.16.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 var path = require('path');
 var loaders = require('./webpack.loaders');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var DashboardPlugin = require('webpack-dashboard/plugin');
 
 const HOST = process.env.HOST || "127.0.0.1";
 const PORT = process.env.PORT || "8888";
@@ -71,6 +72,7 @@ module.exports = {
 	plugins: [
 		new webpack.NoErrorsPlugin(),
 		new webpack.HotModuleReplacementPlugin(),
+		new DashboardPlugin(),
 		new HtmlWebpackPlugin({
 			template: './src/template.html'
 		}),


### PR DESCRIPTION
Hello Ali, I just added a new plugin called [Webpack Dashboard](https://github.com/FormidableLabs/webpack-dashboard)

I think it's really powerfull and usefull to see things like the status of the compiling process and the size of the modules included in a really simple way.

Hope you find it interesting and accept the PR, thanks a lot for your time!