### PR TITLE
MOD: make publicPath relative

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
 	],
 	devtool: process.env.WEBPACK_DEVTOOL || 'eval-source-map',
 	output: {
-		publicPath: '/',
+		publicPath: './',
 		path: path.join(__dirname, 'public'),
 		filename: 'bundle.js'
 	},


### PR DESCRIPTION
the builds were not possible to run under a subfolder on a domain (demo.com/react-demo/index.html). With making the publicPath relative this should work as well as still keeping the same function for people running it on the root (demo.com/index.html)