### PR TITLE
Update React to 15.6.1, fixed npm WARN from webpack 3 upgrade, Fix for issue #265

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   "homepage": "https://github.com/alicoding/react-webpack-babel#readme",
   "dependencies": {
     "node-sass": "^4.3.0",
-    "react": "15.4.2",
+    "react": "15.6.1",
     "react-dom": "15.4.2",
     "sass-loader": "^6.0.2"
   },
   "devDependencies": {
     "babel-core": "^6.23.1",
-    "babel-loader": "^6.3.2",
+    "babel-loader": "^7.1",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.22.0",
@@ -32,7 +32,7 @@
     "babel-preset-react": "^6.23.0",
     "babel-runtime": "^6.22.0",
     "css-loader": "0.26.1",
-    "extract-text-webpack-plugin": "^v2.0.0-rc.1",
+    "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.10.0",
     "html-webpack-plugin": "^2.26.0",
     "postcss-loader": "^1.2.2",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,8 +6,7 @@ import App from './app.jsx';
 render( <AppContainer><App/></AppContainer>, document.querySelector("#app"));
 
 if (module && module.hot) {
-  module.hot.accept('./app.jsx', () => {
-    const App = require('./app.jsx').default;
+  module.hot.accept('./app', () => {
     render(
       <AppContainer>
         <App/>


### PR DESCRIPTION
npm WARN babel-loader@6.4.1 requires a peer of webpack@1 || 2 || ^2.1.0-beta || ^2.2.0-rc but none was installed.
npm WARN extract-text-webpack-plugin@2.1.2 requires a peer of webpack@^2.2.0 but none was installed.
npm WARN ajv-keywords@2.1.0 requires a peer of ajv@>=5.0.0 but none was installed.